### PR TITLE
Add cleanup job for temp files after deps install

### DIFF
--- a/lib/protk/setup_rakefile.rake
+++ b/lib/protk/setup_rakefile.rake
@@ -1,5 +1,6 @@
 
 require 'protk/constants.rb'
+require 'rake/clean'
 require 'rbconfig'
 
 env=Constants.new
@@ -9,6 +10,8 @@ env=Constants.new
 
 directory @build_dir
 directory @download_dir
+
+CLEAN.include @build_dir, @download_dir
 
 def package_manager_name 
 	package_managers = ["brew","yum","apt-get"]


### PR DESCRIPTION
Adds an additional rake task (callable through protk_setup.rb) to delete temporary build and download directories. Uses inbuilt rake clean module.
